### PR TITLE
fix: cache security groups and excess NAT gateway use

### DIFF
--- a/examples/multi-runner/templates/runner-configs/linux-x64-platform.yaml
+++ b/examples/multi-runner/templates/runner-configs/linux-x64-platform.yaml
@@ -27,7 +27,7 @@ runner_config:
     - ${account_id}
   ami_filter:
     name:
-      - github-runner-ubuntu-jammy-platform-amd64-202308020144
+      - github-runner-ubuntu-jammy-platform-amd64-202308040058
     state:
       - available
   block_device_mappings:

--- a/images/ubuntu-jammy-platform/manifest.json
+++ b/images/ubuntu-jammy-platform/manifest.json
@@ -26,7 +26,16 @@
       "artifact_id": "eu-west-1:ami-0856b199d6cf85cce",
       "packer_run_uuid": "62ac4e55-17df-83cc-11d6-4cd7213cb280",
       "custom_data": null
+    },
+    {
+      "name": "githubrunner",
+      "builder_type": "amazon-ebs",
+      "build_time": 1691111487,
+      "files": null,
+      "artifact_id": "eu-west-1:ami-0595dd41daa77b0f0",
+      "packer_run_uuid": "7a8c27c9-2c18-30ce-2092-6364f605bd89",
+      "custom_data": null
     }
   ],
-  "last_run_uuid": "62ac4e55-17df-83cc-11d6-4cd7213cb280"
+  "last_run_uuid": "7a8c27c9-2c18-30ce-2092-6364f605bd89"
 }

--- a/modules/multi-runner/docker_cache/main.tf
+++ b/modules/multi-runner/docker_cache/main.tf
@@ -29,11 +29,9 @@ resource "aws_vpc_security_group_ingress_rule" "docker" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "docker" {
-  security_group_id            = aws_security_group.docker_cache_sg.id
-  referenced_security_group_id = aws_security_group.docker_cache_sg.id
-  ip_protocol                  = "tcp"
-  from_port                    = 5000
-  to_port                      = 5000
+  security_group_id = aws_security_group.docker_cache_sg.id
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
 }
 
 resource "aws_route53_zone" "private" {

--- a/modules/multi-runner/docker_cache/main.tf
+++ b/modules/multi-runner/docker_cache/main.tf
@@ -90,7 +90,7 @@ resource "aws_launch_template" "docker_cache" {
   block_device_mappings {
     device_name = "/dev/sda1"
     ebs {
-      volume_size = 50
+      volume_size = 20
       volume_type = "gp3"
     }
   }

--- a/modules/multi-runner/docker_cache/main.tf
+++ b/modules/multi-runner/docker_cache/main.tf
@@ -20,15 +20,12 @@ resource "aws_security_group" "docker_cache_sg" {
   tags        = var.config.tags
 }
 
-resource "aws_security_group_rule" "docker_ingress" {
-  count = length(var.config.lambda_security_group_ids)
-
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 5000
-  to_port                  = 5000
-  security_group_id        = aws_security_group.docker_cache_sg.id
-  source_security_group_id = var.config.lambda_security_group_ids[count.index]
+resource "aws_vpc_security_group_ingress_rule" "docker" {
+  security_group_id            = aws_security_group.docker_cache_sg.id
+  referenced_security_group_id = aws_security_group.docker_cache_sg.id
+  ip_protocol                  = "tcp"
+  from_port                    = 5000
+  to_port                      = 5000
 }
 
 resource "aws_vpc_security_group_egress_rule" "docker" {

--- a/modules/multi-runner/docker_cache/main.tf
+++ b/modules/multi-runner/docker_cache/main.tf
@@ -20,14 +20,6 @@ resource "aws_security_group" "docker_cache_sg" {
   tags        = var.config.tags
 }
 
-resource "aws_vpc_security_group_ingress_rule" "docker" {
-  security_group_id            = aws_security_group.docker_cache_sg.id
-  referenced_security_group_id = aws_security_group.docker_cache_sg.id
-  ip_protocol                  = "tcp"
-  from_port                    = 5000
-  to_port                      = 5000
-}
-
 resource "aws_vpc_security_group_egress_rule" "docker" {
   security_group_id = aws_security_group.docker_cache_sg.id
   ip_protocol       = "-1"

--- a/modules/multi-runner/docker_cache/outputs.tf
+++ b/modules/multi-runner/docker_cache/outputs.tf
@@ -1,0 +1,3 @@
+output "security_group_id" {
+  value = aws_security_group.docker_cache_sg.id
+}

--- a/modules/multi-runner/docker_cache/templates/user-data/docker_cache_user_data.sh
+++ b/modules/multi-runner/docker_cache/templates/user-data/docker_cache_user_data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 apt-get update -y
-apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
+apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release jq
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 apt-get update -y

--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -50,7 +50,7 @@ module "runners" {
   idle_config                          = each.value.runner_config.idle_config
   enable_ssm_on_runners                = each.value.runner_config.enable_ssm_on_runners
   egress_rules                         = var.runner_egress_rules
-  runner_additional_security_group_ids = try(coalescelist(each.value.runner_config.runner_additional_security_group_ids, var.runner_additional_security_group_ids), [])
+  runner_additional_security_group_ids = try(coalescelist(each.value.runner_config.runner_additional_security_group_ids, var.runner_additional_security_group_ids), [module.docker_cache.security_group_id])
   metadata_options                     = each.value.runner_config.runner_metadata_options
   credit_specification                 = each.value.runner_config.credit_specification
 

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -220,5 +220,7 @@ module "s3_cache" {
     runner_instance_role = {
       arn = aws_iam_role.runner.arn
     }
+    vpc_id     = var.vpc_id
+    aws_region = var.aws_region
   }
 }

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -179,7 +179,7 @@ resource "aws_launch_template" "runner" {
 
 resource "aws_security_group" "runner_sg" {
   count       = var.enable_managed_runner_security_group ? 1 : 0
-  name_prefix = "${var.prefix}-github-actions-runner-sg"
+  name_prefix = "${var.prefix}-github-actions-runner-sg-"
   description = "Github Actions Runner security group"
 
   vpc_id = var.vpc_id

--- a/modules/runners/s3_cache/main.tf
+++ b/modules/runners/s3_cache/main.tf
@@ -42,3 +42,17 @@ resource "aws_s3_bucket_lifecycle_configuration" "runner_cache_bucket_lifecycle_
     status = "Enabled"
   }
 }
+
+data "aws_route_tables" "private" {
+  vpc_id = var.config.vpc_id
+  filter {
+    name   = "tag:Name"
+    values = ["*private"]
+  }
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id          = var.config.vpc_id
+  route_table_ids = data.aws_route_tables.private.ids
+  service_name    = "com.amazonaws.${var.config.aws_region}.s3"
+}

--- a/modules/runners/s3_cache/variables.tf
+++ b/modules/runners/s3_cache/variables.tf
@@ -5,5 +5,7 @@ variable "config" {
     runner_instance_role = object({
       arn = string
     })
+    vpc_id     = string
+    aws_region = string
   })
 }


### PR DESCRIPTION
This PR tidies up some of the SGs around the docker cache and implements an S3 gateway endpoint to reduce costs.