### PR TITLE
fix: OOM during rs-drive-abci tests

### DIFF
--- a/examples/multi-runner/templates/runner-configs/linux-x64-platform.yaml
+++ b/examples/multi-runner/templates/runner-configs/linux-x64-platform.yaml
@@ -27,7 +27,7 @@ runner_config:
     - ${account_id}
   ami_filter:
     name:
-      - github-runner-ubuntu-jammy-platform-amd64-202308040058
+      - github-runner-ubuntu-jammy-platform-amd64-202308142343
     state:
       - available
   block_device_mappings:

--- a/images/ubuntu-jammy-platform/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy-platform/github_agent.ubuntu.pkr.hcl
@@ -44,7 +44,7 @@ variable "instance_type" {
 
 variable "root_volume_size_gb" {
   type    = number
-  default = 8
+  default = 30
 }
 
 variable "ebs_delete_on_termination" {
@@ -146,6 +146,11 @@ build {
     ]
     inline = concat([
       "sudo cloud-init status --wait",
+      "sudo fallocate -l 8G /swapfile",
+      "sudo chmod 600 /swapfile",
+      "sudo mkswap /swapfile",
+      "sudo swapon /swapfile",
+      "echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab",
       "sudo apt-get -y update",
       "sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg",
       "echo deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null",

--- a/images/ubuntu-jammy-platform/manifest.json
+++ b/images/ubuntu-jammy-platform/manifest.json
@@ -35,7 +35,16 @@
       "artifact_id": "eu-west-1:ami-0595dd41daa77b0f0",
       "packer_run_uuid": "7a8c27c9-2c18-30ce-2092-6364f605bd89",
       "custom_data": null
+    },
+    {
+      "name": "githubrunner",
+      "builder_type": "amazon-ebs",
+      "build_time": 1692057252,
+      "files": null,
+      "artifact_id": "eu-west-1:ami-0ccb92866174c0a63",
+      "packer_run_uuid": "df6b6ea3-e599-041d-00c8-33cb5c1783bd",
+      "custom_data": null
     }
   ],
-  "last_run_uuid": "7a8c27c9-2c18-30ce-2092-6364f605bd89"
+  "last_run_uuid": "df6b6ea3-e599-041d-00c8-33cb5c1783bd"
 }


### PR DESCRIPTION
Runners were failing Runners were failing with OOM errors while running rs-drive-abci tests:
```
   = note: clang: error: unable to execute command: Killed
          clang: error: linker command failed due to signal (use -v to see invocation)
```

Investigation showed that 16 GB RAM + 8 GB swap is needed for 8-10 CPU cores. This PR adds 8GB swap to the platform runners. Tests are now green: https://github.com/dashpay/platform/actions/runs/5794871046/job/15892802588