### PR TITLE
chore: pin docker compose to v2.20.2

### DIFF
--- a/examples/multi-runner/templates/runner-configs/linux-x64-platform.yaml
+++ b/examples/multi-runner/templates/runner-configs/linux-x64-platform.yaml
@@ -27,7 +27,7 @@ runner_config:
     - ${account_id}
   ami_filter:
     name:
-      - github-runner-ubuntu-jammy-platform-amd64-202309120459
+      - github-runner-ubuntu-jammy-platform-amd64-202309130354
     state:
       - available
   block_device_mappings:

--- a/images/ubuntu-jammy-platform/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy-platform/github_agent.ubuntu.pkr.hcl
@@ -158,7 +158,7 @@ build {
       "echo 'Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001\n\nPackage: firefox\nPin: version 1:1snap1-0ubuntu2\nPin-Priority: -1\n' | sudo tee /etc/apt/preferences.d/mozilla-firefox",
       "sudo curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg",
       "echo deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main | sudo tee /etc/apt/sources.list.d/nodesource.list",
-      "sudo apt-get -y install automake autotools-dev bsdmainutils build-essential clang cmake containerd.io docker-ce docker-ce-cli firefox gcc git jq libssl-dev libtool libzmq3-dev nodejs openssh-client pkg-config python3 unzip",
+      "sudo apt-get -y install automake autotools-dev bsdmainutils build-essential clang cmake containerd.io docker-ce docker-ce-cli docker-compose-plugin=2.20.2-1~ubuntu.22.04~jammy firefox gcc git jq libssl-dev libtool libzmq3-dev nodejs openssh-client pkg-config python3 unzip",
       "sudo systemctl enable containerd.service",
       "sudo service docker start",
       "sudo usermod -a -G docker ubuntu",

--- a/images/ubuntu-jammy-platform/manifest.json
+++ b/images/ubuntu-jammy-platform/manifest.json
@@ -53,7 +53,16 @@
       "artifact_id": "eu-west-1:ami-0d2f21a41019151de",
       "packer_run_uuid": "90b6dfb1-5215-2fa0-2404-c9c080c5ed91",
       "custom_data": null
+    },
+    {
+      "name": "githubrunner",
+      "builder_type": "amazon-ebs",
+      "build_time": 1694577833,
+      "files": null,
+      "artifact_id": "eu-west-1:ami-09cf9fd46024aa6e6",
+      "packer_run_uuid": "3fa4eef0-2983-d516-79a0-9b0296175c81",
+      "custom_data": null
     }
   ],
-  "last_run_uuid": "90b6dfb1-5215-2fa0-2404-c9c080c5ed91"
+  "last_run_uuid": "3fa4eef0-2983-d516-79a0-9b0296175c81"
 }


### PR DESCRIPTION
CI was failing with `(intermediate value) is not iterable` due to a change in output format in `docker compose ps` with v2.21.0. Pin version to v2.20.2 until dashmate can handle the new format.