### PR TITLE
chore: add cache expiration days var

### DIFF
--- a/examples/multi-runner/templates/runner-configs/linux-x64-platform.yaml
+++ b/examples/multi-runner/templates/runner-configs/linux-x64-platform.yaml
@@ -21,6 +21,7 @@ runner_config:
   enable_jit_config: true
   create_service_linked_role_spot: true
   create_cache_bucket: true
+  cache_expiration_days: 3
   scale_down_schedule_expression: cron(* * * * ? *)
   enable_userdata: false
   ami_owners:

--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -89,6 +89,7 @@ module "runners" {
 
   create_service_linked_role_spot = each.value.runner_config.create_service_linked_role_spot
   create_cache_bucket             = each.value.runner_config.create_cache_bucket
+  cache_expiration_days           = each.value.runner_config.cache_expiration_days
 
   runner_iam_role_managed_policy_arns = each.value.runner_config.runner_iam_role_managed_policy_arns
 

--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -42,6 +42,7 @@ variable "multi_runner_config" {
       ami_kms_key_arn                         = optional(string, "")
       create_service_linked_role_spot         = optional(bool, false)
       create_cache_bucket                     = optional(bool, false)
+      cache_expiration_days                   = optional(number, 10)
       credit_specification                    = optional(string, null)
       delay_webhook_event                     = optional(number, 30)
       disable_runner_autoupdate               = optional(bool, false)
@@ -139,6 +140,7 @@ variable "multi_runner_config" {
         ami_owners: "(Optional) The list of owners used to select the AMI of action runner instances."
         create_service_linked_role_spot: (Optional) create the serviced linked role for spot instances that is required by the scale-up lambda.
         create_cache_bucket: "Create a S3 bucket to hold action cache for ephemeral runners. By default disabled."
+        cache_expiration_days: "The number of days the cache is kept in S3 before it is purged."
         credit_specification: "(Optional) The credit specification of the runner instance_type. Can be unset, `standard` or `unlimited`.
         delay_webhook_event: "The number of seconds the event accepted by the webhook is invisible on the queue before the scale up lambda will receive the event."
         disable_runner_autoupdate: "Disable the auto update of the github runner agent. Be aware there is a grace period of 30 days, see also the [GitHub article](https://github.blog/changelog/2022-02-01-github-actions-self-hosted-runners-can-now-disable-automatic-updates/)"

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -215,12 +215,13 @@ module "s3_cache" {
   source = "./s3_cache"
 
   config = {
-    prefix = var.prefix
-    tags   = local.tags
+    aws_region      = var.aws_region
+    expiration_days = var.cache_expiration_days
+    prefix          = var.prefix
     runner_instance_role = {
       arn = aws_iam_role.runner.arn
     }
-    vpc_id     = var.vpc_id
-    aws_region = var.aws_region
+    tags   = local.tags
+    vpc_id = var.vpc_id
   }
 }

--- a/modules/runners/s3_cache/main.tf
+++ b/modules/runners/s3_cache/main.tf
@@ -37,7 +37,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "runner_cache_bucket_lifecycle_
     id = "expire-cache"
     filter {}
     expiration {
-      days = 10
+      days = var.config.expiration_days
     }
     status = "Enabled"
   }

--- a/modules/runners/s3_cache/variables.tf
+++ b/modules/runners/s3_cache/variables.tf
@@ -1,11 +1,12 @@
 variable "config" {
   type = object({
-    prefix = string
-    tags   = map(string)
+    aws_region      = string
+    expiration_days = number
+    prefix          = string
     runner_instance_role = object({
       arn = string
     })
-    vpc_id     = string
-    aws_region = string
+    tags   = map(string)
+    vpc_id = string
   })
 }

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -349,6 +349,12 @@ variable "create_cache_bucket" {
   default     = false
 }
 
+variable "cache_expiration_days" {
+  description = "(optional) number of days to keep cache objects in the cache bucket"
+  type        = number
+  default     = 10
+}
+
 variable "aws_partition" {
   description = "(optional) partition for the base arn if not 'aws'"
   type        = string


### PR DESCRIPTION
This PR makes the S3 cache expiration duration in days a variable in the runner config, and sets the variable to 2 days for the platform runners.