### PR TITLE
chore: add 8x-ubuntu-platform type to multi-runner

### DIFF
--- a/examples/multi-runner/templates/runner-configs/linux-x64-platform-8x.yaml
+++ b/examples/multi-runner/templates/runner-configs/linux-x64-platform-8x.yaml
@@ -10,9 +10,9 @@ redrive_build_queue:
 runner_config:
   runner_os: linux
   runner_architecture: x64
-  runner_extra_labels: ubuntu-platform
+  runner_extra_labels: 8x-ubuntu-platform
   runner_run_as: ubuntu
-  runner_name_prefix: ubuntu-platform-x64_
+  runner_name_prefix: 8x-ubuntu-platform-x64_
   enable_ssm_on_runners: true
   instance_types:
     - c6id.8xlarge

--- a/examples/multi-runner/templates/runner-configs/linux-x64-platform-8x.yaml
+++ b/examples/multi-runner/templates/runner-configs/linux-x64-platform-8x.yaml
@@ -1,0 +1,48 @@
+matcherConfig:
+  exactMatch: true
+  labelMatchers:
+    - [ self-hosted, linux, x64, 8x-ubuntu-platform ]
+fifo: false
+delay_webhook_event: 0
+redrive_build_queue:
+  enabled: false
+  maxReceiveCount: null
+runner_config:
+  runner_os: linux
+  runner_architecture: x64
+  runner_extra_labels: ubuntu-platform
+  runner_run_as: ubuntu
+  runner_name_prefix: ubuntu-platform-x64_
+  enable_ssm_on_runners: true
+  instance_types:
+    - c6id.8xlarge
+  runners_maximum_count: 15
+  enable_ephemeral_runners: true
+  enable_jit_config: true
+  create_service_linked_role_spot: true
+  create_cache_bucket: true
+  cache_expiration_days: 3
+  scale_down_schedule_expression: cron(* * * * ? *)
+  enable_userdata: false
+  ami_owners:
+    - ${account_id}
+  ami_filter:
+    name:
+      - github-runner-ubuntu-jammy-platform-amd64-202309281930
+    state:
+      - available
+  block_device_mappings:
+    - device_name: /dev/sda1
+      delete_on_termination: true
+      volume_type: gp3
+      volume_size: 30
+      encrypted: true
+      iops: null
+      throughput: null
+      kms_key_id: null
+      snapshot_id: null
+  runner_metadata_options:
+    instance_metadata_tags: enabled
+    http_endpoint: enabled
+    http_tokens: optional
+    http_put_response_hop_limit: 2


### PR DESCRIPTION
We want to be able to trigger more powerful runners for release with `[ self-hosted, linux, x64, 8x-ubuntu-platform ]` labels