### PR TITLE
chore: update runners to use 2.311.0

### DIFF
--- a/examples/multi-runner/templates/runner-configs/linux-x64-core.yaml
+++ b/examples/multi-runner/templates/runner-configs/linux-x64-core.yaml
@@ -25,7 +25,7 @@ runner_config:
     - ${account_id}
   ami_filter:
     name:
-      - github-runner-ubuntu-jammy-core-amd64-202310070149
+      - github-runner-ubuntu-jammy-core-amd64-202311220009
     state:
       - available
   block_device_mappings:

--- a/images/ubuntu-jammy-core/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy-core/github_agent.ubuntu.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "runner_version" {
   description = "The version (no v prefix) of the runner software to install https://github.com/actions/runner/releases. The latest release will be fetched from GitHub if not provided."
-  default     = "2.309.0"
+  default     = "2.311.0"
 }
 
 variable "region" {


### PR DESCRIPTION
Update core image to 2.311.0